### PR TITLE
fix varUint size check and serialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /*.so
 /*.lib
 /*.dll
+
+.vscode
+.DS_Store

--- a/src/tests/v1/full_stack_tests.rs
+++ b/src/tests/v1/full_stack_tests.rs
@@ -16,7 +16,6 @@ use ed25519::signature::{Signature, Signer};
 use ton_types::{BuilderData, SliceData};
 use ton_types::dictionary::HashmapE;
 use ton_block::{MsgAddressInt, Serializable};
-use serde_json::json;
 
 use json_abi::*;
 
@@ -433,80 +432,4 @@ fn test_update_decode_contract_data() {
         serde_json::from_str::<Value>(params).unwrap(),
         serde_json::from_str::<Value>(&decoded).unwrap()
     );
-}
-
-fn value_helper(abi_type: &str, value: &str) -> Result<BuilderData> {
-    let abi = json!({
-        "ABI version": 2,
-        "version": "2.3",
-        "functions": [
-          {"name": "test","inputs": [{"name":"value","type":abi_type}],"outputs": []}
-        ],
-        "events": [],
-        "data": []
-    }).to_string();
-    let params = json!({"value": value}).to_string();
-    encode_function_call(
-        abi,
-        "test".to_owned(),
-        None,
-        params.to_owned(),
-        false,
-        None,
-        None,
-    )
-}
-
-#[test]
-fn test_max_varuint32() {
-    // value max bit size (2 ** log2(32) - 1) * 8
-    let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    let encoded = value_helper("varuint32", value).unwrap();
-    println!("{}", encoded);
-    assert_eq!(
-        encoded.data(),
-        &hex::decode("1869a0307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc").unwrap()
-    );
-    assert_eq!(encoded.length_in_bits(), 286);
-    assert_eq!(encoded.references().len(), 0);
-}
-
-#[test]
-fn test_max_varint32() {
-    // value max bit size (2 ** log2(32) - 1) * 8
-    let value = "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    let encoded = value_helper("varint32", value).unwrap();
-    println!("{}", encoded);
-    assert_eq!(
-        encoded.data(),
-        &hex::decode("30d82fc87dfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc").unwrap()
-    );
-    assert_eq!(encoded.length_in_bits(), 286);
-    assert_eq!(encoded.references().len(), 0);
-}
-
-#[test]
-fn test_max_uint() {
-    let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    let encoded = value_helper("uint256", value).unwrap();
-    println!("{}", encoded);
-    assert_eq!(
-        encoded.data(),
-        &hex::decode("3a8707b37fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80").unwrap()
-    );
-    assert_eq!(encoded.length_in_bits(), 289);
-    assert_eq!(encoded.references().len(), 0);
-}
-
-#[test]
-fn test_max_int() {
-    let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-    let encoded = value_helper("int257", value).unwrap();
-    println!("{}", encoded);
-    assert_eq!(
-        encoded.data(),
-        &hex::decode("088fb044bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0").unwrap()
-    );
-    assert_eq!(encoded.length_in_bits(), 290);
-    assert_eq!(encoded.references().len(), 0);
 }

--- a/src/tests/v2/full_stack_tests.rs
+++ b/src/tests/v2/full_stack_tests.rs
@@ -19,6 +19,8 @@ use ton_block::{MsgAddressInt, Serializable};
 
 use json_abi::*;
 
+use serde_json::json;
+
 const WALLET_ABI: &str = r#"{
     "ABI version": 2,
     "header": [
@@ -655,4 +657,80 @@ fn test_signed_call_v23() {
 
     assert_eq!(response.params, expected_response);
     assert_eq!(response.function_name, "createArbitraryLimit");
+}
+
+fn value_helper(abi_type: &str, value: &str) -> Result<BuilderData> {
+    let abi = json!({
+        "ABI version": 2,
+        "version": "2.3",
+        "functions": [
+          {"name": "test","inputs": [{"name":"value","type":abi_type}],"outputs": []}
+        ],
+        "events": [],
+        "data": []
+    }).to_string();
+    let params = json!({"value": value}).to_string();
+    encode_function_call(
+        abi,
+        "test".to_owned(),
+        None,
+        params.to_owned(),
+        false,
+        None,
+        None,
+    )
+}
+
+#[test]
+fn test_max_varuint32() {
+    // value max bit size (2 ** log2(32) - 1) * 8
+    let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let encoded = value_helper("varuint32", value).unwrap();
+
+    assert_eq!(
+        encoded.data(),
+        &hex::decode("1869a0307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc").unwrap()
+    );
+    assert_eq!(encoded.length_in_bits(), 286);
+    assert_eq!(encoded.references().len(), 0);
+}
+
+#[test]
+fn test_max_varint32() {
+    // value max bit size (2 ** log2(32) - 1) * 8
+    let value = "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let encoded = value_helper("varint32", value).unwrap();
+
+    assert_eq!(
+        encoded.data(),
+        &hex::decode("30d82fc87dfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc").unwrap()
+    );
+    assert_eq!(encoded.length_in_bits(), 286);
+    assert_eq!(encoded.references().len(), 0);
+}
+
+#[test]
+fn test_max_uint() {
+    let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let encoded = value_helper("uint256", value).unwrap();
+
+    assert_eq!(
+        encoded.data(),
+        &hex::decode("3a8707b37fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff80").unwrap()
+    );
+    assert_eq!(encoded.length_in_bits(), 289);
+    assert_eq!(encoded.references().len(), 0);
+}
+
+#[test]
+fn test_max_int() {
+    let value = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+    let encoded = value_helper("int257", value).unwrap();
+
+    assert_eq!(
+        encoded.data(),
+        &hex::decode("088fb044bfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0").unwrap()
+    );
+    assert_eq!(encoded.length_in_bits(), 290);
+    assert_eq!(encoded.references().len(), 0);
 }

--- a/src/token/serialize.rs
+++ b/src/token/serialize.rs
@@ -200,15 +200,7 @@ impl TokenValue {
         Self::write_int(&int)
     }
 
-    fn write_varint(value: &BigInt, size: usize) -> Result<BuilderData> {
-        let vec = value.to_signed_bytes_be();
-
-        if vec.len() > size - 1 {
-            fail!(AbiError::InvalidData {
-                msg: format!("Too long value for varint{}: {}", size, value)
-            });
-        }
-
+    fn write_varnumber(vec: &Vec<u8>, size: usize) -> Result<BuilderData> {
         let mut builder = BuilderData::new();
         let bits = ParamType::varint_size_len(size);
         if vec != &[0] {
@@ -221,10 +213,26 @@ impl TokenValue {
         Ok(builder)
     }
 
-    fn write_varuint(value: &BigUint, size: usize) -> Result<BuilderData> {
-        let big_int = BigInt::from_biguint(Sign::Plus, value.clone());
+    fn write_varint(value: &BigInt, size: usize) -> Result<BuilderData> {
+        let vec = value.to_signed_bytes_be();
 
-        Self::write_varint(&big_int, size)
+        if vec.len() > size - 1 {
+            fail!(AbiError::InvalidData {
+                msg: format!("Too long value for varint{}: {}", size, value)
+            });
+        }
+        Self::write_varnumber(&vec, size)
+    }
+
+    fn write_varuint(value: &BigUint, size: usize) -> Result<BuilderData> {
+        let vec = value.to_bytes_be();
+
+        if vec.len() > size - 1 {
+            fail!(AbiError::InvalidData {
+                msg: format!("Too long value for varuint{}: {}", size, value)
+            });
+        }
+        Self::write_varnumber(&vec, size)
     }
 
     fn write_bool(value: &bool) -> Result<BuilderData> {

--- a/src/token/tokenizer.rs
+++ b/src/token/tokenizer.rs
@@ -320,7 +320,7 @@ impl Tokenizer {
     fn tokenize_varuint(size: usize, value: &Value, name: &str) -> Result<TokenValue> {
         let number = Self::read_uint(value, name)?;
 
-        if !Self::check_uint_size(&number, (size - 1) * 8) {
+        if !Self::check_uint_size(&number, (size - 1) * 8 + 1) {
             fail!(AbiError::InvalidParameterValue {
                 val: value.clone(),
                 name: name.to_string(),


### PR DESCRIPTION
incorrect size for varuint, size need increment like in tokenize_uint

```
"Error": "failed to create inbound message: Create run message failed: Invalid parameter `amount` value:\n\"0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff\"\nprovided number is out of type range"
```